### PR TITLE
refactor: implement private scheme for test environments to prevent r…

### DIFF
--- a/internal/controller/envtest_helpers_race_test.go
+++ b/internal/controller/envtest_helpers_race_test.go
@@ -8,14 +8,11 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-
-	ipamv1 "github.com/appthrust/plexaubnet/api/v1alpha1"
 )
 
 // setupEnvTest sets up a controller-runtime envtest environment and registers the CRDs.
@@ -23,9 +20,8 @@ import (
 func setupEnvTest(t *testing.T) (*envtest.Environment, *runtime.Scheme) {
 	t.Helper()
 
-	// Create a private scheme for this test to avoid race conditions
-	testScheme := runtime.NewScheme()
-	utilruntime.Must(ipamv1.AddToScheme(testScheme))
+	// Use the common helper function to create a private scheme
+	testScheme := NewTestScheme()
 
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{"../../config/crd/bases"},

--- a/internal/controller/high_load_test.go
+++ b/internal/controller/high_load_test.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,9 +44,8 @@ import (
 
 // Helper function to set up the test environment
 func setupEnvTest(t *testing.T) (*envtest.Environment, *runtime.Scheme) {
-	// Create a private scheme for this test to avoid race conditions
-	testScheme := runtime.NewScheme()
-	utilruntime.Must(ipamv1.AddToScheme(testScheme))
+	// Use helper to create private scheme with all required types
+	testScheme := NewTestScheme()
 
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{"../../config/crd/bases"},

--- a/internal/controller/high_load_test.go
+++ b/internal/controller/high_load_test.go
@@ -30,8 +30,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,9 +44,14 @@ import (
 )
 
 // Helper function to set up the test environment
-func setupEnvTest(t *testing.T) *envtest.Environment {
+func setupEnvTest(t *testing.T) (*envtest.Environment, *runtime.Scheme) {
+	// Create a private scheme for this test to avoid race conditions
+	testScheme := runtime.NewScheme()
+	utilruntime.Must(ipamv1.AddToScheme(testScheme))
+
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{"../../config/crd/bases"},
+		Scheme:            testScheme, // Use our private scheme
 	}
 
 	cfg, err := testEnv.Start()
@@ -57,12 +63,10 @@ func setupEnvTest(t *testing.T) *envtest.Environment {
 	cfg.QPS = 200   // Significantly increased from default 5
 	cfg.Burst = 400 // Significantly increased from default 10
 
-	err = ipamv1.AddToScheme(scheme.Scheme)
-	if err != nil {
-		t.Fatalf("Error adding scheme: %v", err)
-	}
+	// Note: we don't need to call ipamv1.AddToScheme(scheme.Scheme) anymore
+	// since the types are already registered in our private scheme
 
-	return testEnv
+	return testEnv, testScheme
 }
 
 // Helper function to stop the test environment
@@ -73,16 +77,16 @@ func stopEnvTest(t *testing.T, testEnv *envtest.Environment) {
 }
 
 // Helper function to create a k8s client
-func createK8sClient(cfg *rest.Config) (client.Client, error) {
-	// Use existing Scheme
-	return client.New(cfg, client.Options{Scheme: scheme.Scheme})
+func createK8sClient(cfg *rest.Config, s *runtime.Scheme) (client.Client, error) {
+	// Use the provided private scheme
+	return client.New(cfg, client.Options{Scheme: s})
 }
 
 // Helper function to set up the manager
-func setupManager(cfg *rest.Config) (ctrl.Manager, error) {
+func setupManager(cfg *rest.Config, s *runtime.Scheme) (ctrl.Manager, error) {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme: s, // Use the provided private scheme
 		Metrics: metricsserver.Options{
 			BindAddress: "0", // Disable metrics server
 		},
@@ -112,8 +116,8 @@ func TestHighLoad1000SubnetClaimCreate(t *testing.T) {
 	initialGoroutines := goruntime.NumGoroutine()
 	t.Logf("Initial goroutines: %d", initialGoroutines)
 
-	// Setup test environment
-	testEnv := setupEnvTest(t)
+	// Setup test environment with private scheme
+	testEnv, testScheme := setupEnvTest(t)
 	defer stopEnvTest(t, testEnv)
 
 	// Get test environment configuration
@@ -122,8 +126,8 @@ func TestHighLoad1000SubnetClaimCreate(t *testing.T) {
 		t.Fatalf("Failed to start test env: %v", err)
 	}
 
-	// Create client
-	k8sClient, err := createK8sClient(cfg)
+	// Create client using our private scheme
+	k8sClient, err := createK8sClient(cfg, testScheme)
 	if err != nil {
 		t.Fatalf("Failed to create k8s client: %v", err)
 	}
@@ -167,9 +171,9 @@ func TestHighLoad1000SubnetClaimCreate(t *testing.T) {
 	startHeap := &goruntime.MemStats{}
 	goruntime.ReadMemStats(startHeap)
 
-	// Start controller
+	// Start controller with our private scheme
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-	mgr, err := setupManager(cfg)
+	mgr, err := setupManager(cfg, testScheme)
 	if err != nil {
 		t.Fatalf("Failed to setup manager: %v", err)
 	}
@@ -379,8 +383,8 @@ func TestParentPoolContentionWithClaims(t *testing.T) {
 		t.Skip("Skipping parent pool contention test in short mode")
 	}
 
-	// Setup test environment
-	testEnv := setupEnvTest(t)
+	// Setup test environment with private scheme
+	testEnv, testScheme := setupEnvTest(t)
 	defer stopEnvTest(t, testEnv)
 
 	// Get test environment configuration
@@ -389,8 +393,8 @@ func TestParentPoolContentionWithClaims(t *testing.T) {
 		t.Fatalf("Failed to start test env: %v", err)
 	}
 
-	// Create client
-	k8sClient, err := createK8sClient(cfg)
+	// Create client using our private scheme
+	k8sClient, err := createK8sClient(cfg, testScheme)
 	if err != nil {
 		t.Fatalf("Failed to create k8s client: %v", err)
 	}
@@ -438,9 +442,9 @@ func TestParentPoolContentionWithClaims(t *testing.T) {
 		t.Fatalf("Failed to create pool: %v", err)
 	}
 
-	// Start controller
+	// Start controller with our private scheme
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-	mgr, err := setupManager(cfg)
+	mgr, err := setupManager(cfg, testScheme)
 	if err != nil {
 		t.Fatalf("Failed to setup manager: %v", err)
 	}

--- a/internal/controller/parent_pool_integration_test.go
+++ b/internal/controller/parent_pool_integration_test.go
@@ -29,9 +29,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,9 +91,8 @@ func TestMain(m *testing.M) {
 
 	// Start envtest environment
 	fmt.Println("Parent Pool Integration Test: Setting up envtest environment...")
-	// Create a private scheme for this test suite to avoid race conditions
-	testScheme := runtime.NewScheme()
-	utilruntime.Must(ipamv1.AddToScheme(testScheme))
+	// Use common helper to create private scheme with all required types
+	testScheme := NewTestScheme()
 
 	parentPoolTestEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},

--- a/internal/controller/test_helpers.go
+++ b/internal/controller/test_helpers.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cidrallocator
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	ipamv1 "github.com/appthrust/plexaubnet/api/v1alpha1"
+)
+
+// NewTestScheme creates a new scheme for testing purposes.
+// This avoids race conditions where multiple test suites try to
+// register types to the global scheme.Scheme concurrently.
+func NewTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(ipamv1.AddToScheme(s))
+	// +kubebuilder:scaffold:scheme
+	return s
+}


### PR DESCRIPTION
race conditions

- Updated test environment setup functions to create and use a private scheme, ensuring thread safety during concurrent test execution.
- Modified client and manager creation functions to accept the private scheme, enhancing isolation in tests.
- Removed redundant scheme registration calls, as types are now registered in the private scheme.
- Introduced a new helper function, NewTestScheme, to streamline scheme creation for tests.